### PR TITLE
Updating terraform block version requirements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 3.24.1"
     }
   }
-  required_version = "~> 0.14"
+  required_version = "~> 0.15"
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 3.24.1"
     }
   }
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 provider "aws" {


### PR DESCRIPTION
While completing this tutorial I noticed the terraform version label was ~> 0.14 but "terraform plan -refresh-only" was introduced in 0.15.4. 